### PR TITLE
Fix command to install from source

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,10 +25,10 @@ To install directly from github using `pip`:
 $ pip install git+https://github.com/kevin-tracy/qpax
 ```
 
-Alternatively, to install from source:
+Alternatively, to install from source in editable mode:
 
 ```bash
-$ python setup.py install
+$ pip install -e .
 ```
 
 ## Usage


### PR DESCRIPTION
Thanks a lot for the great work on this library @kevin-tracy !

I noticed that the `python setup.py install` command is failing with:

~~~
(testqpax) traversaro@IITBMP014LW012:~/qpax$ python setup.py install
python: can't open file '/home/traversaro/qpax/setup.py': [Errno 2] No such file or directory
~~~

I guess this is a leftover of https://github.com/kevin-tracy/qpax/pull/2, I tried to fix it with a command commonly used to install a dependency from source (in editable mode), feel free to suggest further modifications.