### PR TITLE
Cholesky factorization option

### DIFF
--- a/qpax/elastic_qp.py
+++ b/qpax/elastic_qp.py
@@ -1,7 +1,7 @@
 import jax
 import jax.numpy as jnp
 
-from qpax.pdip import centering_params, ort_linesearch, qr_solve
+from qpax.pdip import centering_params, ort_linesearch, factorized_solve, factorize
 
 DEBUG_FLAG = False
 
@@ -12,8 +12,8 @@ def solve_init_elastic_ls(Q, q, G, h, penalty):
     r2 = penalty * jnp.ones(ns)
     r4 = h
 
-    L_H = jnp.linalg.qr(Q + 0.5 * G.T @ G)
-    x = qr_solve(L_H, r1 - 0.5 * G.T @ (r2 - r4))
+    L_H = factorize(Q + 0.5 * G.T @ G)
+    x = factorized_solve(L_H, r1 - 0.5 * G.T @ (r2 - r4))
     z2 = 0.5 * (G @ x + r2 - r4)
     z1 = r2 - z2
     t = -z1
@@ -59,8 +59,8 @@ def solve_elastic_kkt_affine(s1, z1, s2, z2, Q, G, r1, r2, r3, r4, r5, r6):
 
     # one linear system solve
     H = Q + G.T @ (G.T * (1 / a3)).T
-    L_H = jnp.linalg.qr(H)
-    dx = qr_solve(L_H, r1 - G.T @ (p1 / a3))
+    L_H = factorize(H)
+    dx = factorized_solve(L_H, r1 - G.T @ (p1 / a3))
 
     # rest is easy
     dz2 = (p1 + G @ dx) / a3
@@ -84,7 +84,7 @@ def solve_elastic_kkt_cc(L_H, s1, z1, s2, z2, Q, G, r1, r2, r3, r4, r5, r6):
 
     # one linear system solve
     # dx = jnp.linalg.solve(Q + G.T @ (G.T * (1 / a3)).T, r1 - G.T @ (p1 / a3))
-    dx = qr_solve(L_H, r1 - G.T @ (p1 / a3))
+    dx = factorized_solve(L_H, r1 - G.T @ (p1 / a3))
 
     # rest is easy
     dz2 = (p1 + G @ dx) / a3

--- a/qpax/pdip.py
+++ b/qpax/pdip.py
@@ -6,8 +6,7 @@ import jax
 import jax.numpy as jnp
 import jax.scipy as jsp
 
-# FACTORIZATION = "qr"
-FACTORIZATION = "cholesky"
+FACTORIZATION = "qr" # Or "cholesky"
 
 def factorized_solve(factorization, rhs):
     """Solve a linear system using QR or Cholesky decomposition."""

--- a/qpax/pdip.py
+++ b/qpax/pdip.py
@@ -6,22 +6,39 @@ import jax
 import jax.numpy as jnp
 import jax.scipy as jsp
 
+# FACTORIZATION = "qr"
+FACTORIZATION = "cholesky"
 
-def qr_solve(qr, rhs):
-    """Solve a linear system using the QR decomposition."""
-    return jsp.linalg.solve_triangular(qr[1], qr[0].T @ rhs)
+def factorized_solve(factorization, rhs):
+    """Solve a linear system using QR or Cholesky decomposition."""
+    if FACTORIZATION == "cholesky":
+        y = jsp.linalg.solve_triangular(factorization, rhs, lower=True)
+        x = jsp.linalg.solve_triangular(factorization.T, y, lower=False)
+        return x
+    elif FACTORIZATION == "qr":
+        return jsp.linalg.solve_triangular(factorization[1], factorization[0].T @ rhs)
+    else:
+        raise ValueError(f"Unknown factorization: {FACTORIZATION}. Must be 'qr' or 'cholesky'")
+
+def factorize(mat):
+    if FACTORIZATION == "cholesky":
+        return jnp.linalg.cholesky(mat)
+    elif FACTORIZATION == "qr":
+        return jnp.linalg.qr(mat)
+    else:
+        raise ValueError(f"Unknown factorization: {FACTORIZATION}. Must be 'qr' or 'cholesky'")
 
 
 def initialize(Q, q, A, b, G, h):
     """Initialize primal and dual variables from CVXGEN/CVXOPT."""
     H = Q + G.T @ G
-    L_H = jnp.linalg.qr(H)
-    F = A @ qr_solve(L_H, A.T)
-    L_F = jnp.linalg.qr(F)
+    L_H = factorize(H)
+    F = A @ factorized_solve(L_H, A.T)
+    L_F = factorize(F)
 
     r1 = -q + G.T @ h
-    y = qr_solve(L_F, A @ qr_solve(L_H, r1) - b)
-    x = qr_solve(L_H, r1 - A.T @ y)
+    y = factorized_solve(L_F, A @ factorized_solve(L_H, r1) - b)
+    x = factorized_solve(L_H, r1 - A.T @ y)
     z = G @ x - h
 
     alpha_p = -jnp.min(-z)
@@ -39,9 +56,9 @@ def factorize_kkt(Q, G, A, s, z):
     """Factorize the KKT system."""
     P_inv_vec = z / s
     H = Q + G.T @ (G.T * P_inv_vec).T
-    L_H = jnp.linalg.qr(H)
-    F = A @ qr_solve(L_H, A.T)
-    L_F = jnp.linalg.qr(F)
+    L_H = factorize(H)
+    F = A @ factorized_solve(L_H, A.T)
+    L_F = factorize(F)
 
     return P_inv_vec, L_H, L_F
 
@@ -55,8 +72,8 @@ def solve_kkt_rhs(Q, G, A, s, z, P_inv_vec, L_H, L_F, v1, v2, v3, v4):
     r2 = v3 - v2 / z
     p1 = v1 + G.T @ (P_inv_vec * r2)
 
-    dy = qr_solve(L_F, A @ qr_solve(L_H, p1) - v4)
-    dx = qr_solve(L_H, p1 - A.T @ dy)
+    dy = factorized_solve(L_F, A @ factorized_solve(L_H, p1) - v4)
+    dx = factorized_solve(L_H, p1 - A.T @ dy)
     ds = v3 - G @ dx
     dz = (v2 - z * ds) / s
 
@@ -136,16 +153,16 @@ def pdip_pc_step(inputs):
 
 def solve_eq_only(Q, q, A, b):
     """Solve equality constrained QP (Boyd, Convex, pg 559)."""
-    Q_f = jnp.linalg.qr(Q)
+    Q_f = factorize(Q)
 
-    Qinv_At = qr_solve(Q_f, A.T)
-    Qinv_g = qr_solve(Q_f, q)
+    Qinv_At = factorized_solve(Q_f, A.T)
+    Qinv_g = factorized_solve(Q_f, q)
 
     S = -A @ Qinv_At
-    S_f = jnp.linalg.qr(S)
-    y = qr_solve(S_f, A @ Qinv_g + b)
+    S_f = factorize(S)
+    y = factorized_solve(S_f, A @ Qinv_g + b)
 
-    x = qr_solve(Q_f, -A.T @ y - q)
+    x = factorized_solve(Q_f, -A.T @ y - q)
 
     return x, y
 

--- a/qpax/pdip.py
+++ b/qpax/pdip.py
@@ -11,9 +11,7 @@ FACTORIZATION = "qr" # Or "cholesky"
 def factorized_solve(factorization, rhs):
     """Solve a linear system using QR or Cholesky decomposition."""
     if FACTORIZATION == "cholesky":
-        y = jsp.linalg.solve_triangular(factorization, rhs, lower=True)
-        x = jsp.linalg.solve_triangular(factorization.T, y, lower=False)
-        return x
+        return jsp.linalg.cho_solve(factorization, rhs)
     elif FACTORIZATION == "qr":
         return jsp.linalg.solve_triangular(factorization[1], factorization[0].T @ rhs)
     else:
@@ -21,7 +19,7 @@ def factorized_solve(factorization, rhs):
 
 def factorize(mat):
     if FACTORIZATION == "cholesky":
-        return jnp.linalg.cholesky(mat)
+        return jsp.linalg.cho_factor(mat)
     elif FACTORIZATION == "qr":
         return jnp.linalg.qr(mat)
     else:

--- a/test/test_elastic_qp.py
+++ b/test/test_elastic_qp.py
@@ -56,6 +56,8 @@ def create_elastic_problem(Q, q, G, h, penalty):
 
 
 def test_with_qpax():
+    np.random.seed(0)
+
     Q, q, G, h, penalty, x_sol, t_sol, s1_sol, s2_sol, z1_sol, z2_sol = load_problem_data()
 
     x_i, t_i, s1_i, s2_i, z1_i, z2_i = load_initial_values()
@@ -144,4 +146,5 @@ def test_with_qpax():
     assert jnp.linalg.norm(grads1[3] - grads2[3]) < 1e-3
 
 
-test_with_qpax()
+if __name__ == "__main__":
+    test_with_qpax()

--- a/test/test_qp_solver_double.py
+++ b/test/test_qp_solver_double.py
@@ -48,3 +48,6 @@ def test_qp_solver():
         assert iters <= 20  # this is much stricter than the continuation criteria
 
         check_kkt_conditions(Q, q, A, b, G, h, x, s, z, y, solver_tol=solver_tol)
+
+if __name__ == "__main__":
+    test_qp_solver()

--- a/test/test_qp_solver_single.py
+++ b/test/test_qp_solver_single.py
@@ -56,3 +56,6 @@ def test_qp_solver():
         assert iters <= 10  # this is much stricter than the continuation criteria
 
         check_kkt_conditions(Q, q, A, b, G, h, x, s, z, y, solver_tol=solver_tol)
+
+if __name__ == "__main__":
+    test_qp_solver()

--- a/test/test_speed.py
+++ b/test/test_speed.py
@@ -27,7 +27,7 @@ def test_solver(
 
     # Determine solve times from jitted solver
     times = []
-    for _ in range(1000):
+    for _ in range(n_test):
         Q, q, A, b, G, h, x_true, s_true, z_true, y_true = generate_random_qp(
             nx, ns, ny
         )

--- a/test/test_speed.py
+++ b/test/test_speed.py
@@ -1,0 +1,84 @@
+from functools import partial
+import time
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+from misc_test_utils import check_kkt_conditions, generate_random_qp
+
+import qpax
+
+
+def test_solver(
+    nx, ns, ny, n_test=1000, solver_tol=1e-6, elastic=False, elastic_penalty=1e3
+):
+
+    @jax.jit
+    def solve_primal(Q, q, A, b, G, h):
+        if elastic:
+            return qpax.solve_qp_elastic_primal(Q, q, G, h, elastic_penalty, solver_tol)
+        return qpax.solve_qp_primal(Q, q, A, b, G, h, solver_tol=solver_tol)
+
+    # Initial solve for jit-compilation
+    Q, q, A, b, G, h, x_true, s_true, z_true, y_true = generate_random_qp(nx, ns, ny)
+    start_time = time.perf_counter()
+    _ = solve_primal(Q, q, A, b, G, h).block_until_ready()
+    jit_time = time.perf_counter() - start_time
+
+    # Determine solve times from jitted solver
+    times = []
+    for _ in range(1000):
+        Q, q, A, b, G, h, x_true, s_true, z_true, y_true = generate_random_qp(
+            nx, ns, ny
+        )
+        start_time = time.perf_counter()
+        _ = solve_primal(Q, q, A, b, G, h).block_until_ready()
+        times.append(time.perf_counter() - start_time)
+
+    mean_solve_time = np.mean(times)
+    std_solve_time = np.std(times)
+
+    print(f"Jit compilation time: {jit_time}")
+    print(f"Mean: {mean_solve_time * 1e6} microseconds")
+    print(f"Std: {std_solve_time * 1e6} microseconds")
+
+
+def run_tests(elastic=False):
+    np.random.seed(1)
+
+    print(f"\n== Speed test: {'elastic' if elastic else 'regular'} QP solver ==\n")
+
+    if not elastic:
+        # Normal QPs
+        nx = 15
+        ns = 10
+        ny = 3
+        print("Testing inequality/equality constrained QPs")
+        test_solver(nx, ns, ny, elastic=elastic)
+
+    # Inequality-only QP's
+    nx = 15
+    ns = 10
+    ny = 0
+    print("\nTesting inequality-only constrained QPs")
+    test_solver(nx, ns, ny, elastic=elastic)
+
+    if not elastic:
+        # Larger normal QPs
+        nx = 45
+        ns = 30
+        ny = 9
+        print("\nTesting larger inequality/equality constrained QPs")
+        test_solver(nx, ns, ny, elastic=elastic)
+
+    # Larger Inequality-only QP's
+    nx = 45
+    ns = 30
+    ny = 0
+    print("\nTesting larger inequality-only constrained QPs")
+    test_solver(nx, ns, ny, elastic=elastic)
+
+
+if __name__ == "__main__":
+    run_tests(elastic=False)
+    run_tests(elastic=True)

--- a/test/test_speed_double.py
+++ b/test/test_speed_double.py
@@ -1,0 +1,15 @@
+import jax
+
+jax.config.update("jax_enable_x64", True)
+
+from test_speed import run_tests
+
+
+def main():
+    print("Using double precision.\n")
+    run_tests(elastic=False)
+    run_tests(elastic=True)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Hey Kevin, I've been messing around with QP solvers a bunch recently and finally had a chance to try out cholesky factorization (https://github.com/kevin-tracy/qpax/issues/13). I'm seeing a pretty consistent 30% - 100% speedup on general QPs as compared to QR, and about a 10% boost on my CBFpy/OSCBF packages.

I was hoping I could just pass the factorization method as an input, but passing this non-differentiable argument around was a bit of a hassle without more refactoring. So, right now the factorization method is just set as a constant

I kept the default factorization method as QR for now -- I figured that might be best to not change things across pip-installed versions, but let me know what you think

Here's some speed test results:

Cholesky: 
```
== Double Precision == 

== Speed test: regular QP solver ==

Testing inequality/equality constrained QPs
Jit compilation time: 0.40895020199241117
Mean: 45.22116365842521 microseconds
Std: 3.9778773370757685 microseconds

Testing inequality-only constrained QPs
Jit compilation time: 0.2596608800231479
Mean: 29.999127495102584 microseconds
Std: 2.1835691766892764 microseconds

Testing larger inequality/equality constrained QPs
Jit compilation time: 0.3278441879665479
Mean: 200.62689582118765 microseconds
Std: 19.06644569711005 microseconds

Testing larger inequality-only constrained QPs
Jit compilation time: 0.2711773189948872
Mean: 143.88431649422273 microseconds
Std: 11.195591510544046 microseconds

== Speed test: elastic QP solver ==

Testing inequality-only constrained QPs
Jit compilation time: 0.28358743502758443
Mean: 48.81111631402746 microseconds
Std: 2.7549475357237667 microseconds

Testing larger inequality-only constrained QPs
Jit compilation time: 0.3348115250119008
Mean: 256.27431221073493 microseconds
Std: 12.214209269797498 microseconds

== Single Precision ==

== Speed test: regular QP solver ==

Testing inequality/equality constrained QPs
Jit compilation time: 0.393904589000158
Mean: 138.62008712021634 microseconds
Std: 12.102538901478 microseconds

Testing inequality-only constrained QPs
Jit compilation time: 0.25198986497707665
Mean: 92.39398286445066 microseconds
Std: 1.6653548028471832 microseconds

Testing larger inequality/equality constrained QPs
Jit compilation time: 0.3900480140000582
Mean: 566.5959436446428 microseconds
Std: 10.491507573709463 microseconds

Testing larger inequality-only constrained QPs
Jit compilation time: 0.2917474419809878
Mean: 348.08792278636247 microseconds
Std: 7.8469233632866615 microseconds

== Speed test: elastic QP solver ==

Testing inequality-only constrained QPs
Jit compilation time: 0.28329819394275546
Mean: 101.94376378785819 microseconds
Std: 2.4287049347472953 microseconds

Testing larger inequality-only constrained QPs
Jit compilation time: 0.3495480650453828
Mean: 377.7920471620746 microseconds
Std: 16.724932765873174 microseconds
```

QR
```
== Double Precision ==

== Speed test: regular QP solver ==

Testing inequality/equality constrained QPs
Jit compilation time: 0.4352744600037113
Mean: 62.86182923940942 microseconds
Std: 5.224869913041549 microseconds

Testing inequality-only constrained QPs
Jit compilation time: 0.23667118302546442
Mean: 49.00507046841085 microseconds
Std: 4.105995959217504 microseconds

Testing larger inequality/equality constrained QPs
Jit compilation time: 0.38492397795198485
Mean: 424.2599433637224 microseconds
Std: 34.58383967250798 microseconds

Testing larger inequality-only constrained QPs
Jit compilation time: 0.2704834869946353
Mean: 324.46795591386035 microseconds
Std: 26.166761211275272 microseconds

== Speed test: elastic QP solver ==

Testing inequality-only constrained QPs
Jit compilation time: 0.2914215379860252
Mean: 88.70983362430707 microseconds
Std: 6.284606734080228 microseconds

Testing larger inequality-only constrained QPs
Jit compilation time: 0.3540838059852831
Mean: 560.0564912892878 microseconds
Std: 26.91928872903381 microseconds

== Single Precision == 

== Speed test: regular QP solver ==

Testing inequality/equality constrained QPs
Jit compilation time: 0.4640993479988538
Mean: 247.03300814144316 microseconds
Std: 2.8702168771892342 microseconds

Testing inequality-only constrained QPs
Jit compilation time: 0.25965982902562246
Mean: 164.7790558054112 microseconds
Std: 6.498939299551702 microseconds

Testing larger inequality/equality constrained QPs
Jit compilation time: 0.4111563080223277
Mean: 1239.1178520047106 microseconds
Std: 17.18725461566325 microseconds

Testing larger inequality-only constrained QPs
Jit compilation time: 0.2841646860470064
Mean: 970.0429336517118 microseconds
Std: 13.421481377361554 microseconds

== Speed test: elastic QP solver ==

Testing inequality-only constrained QPs
Jit compilation time: 0.3082722270046361
Mean: 175.65850267419592 microseconds
Std: 5.4330953195648926 microseconds

Testing larger inequality-only constrained QPs
Jit compilation time: 0.3611417879583314
Mean: 1025.3470587776974 microseconds
Std: 23.539309468699308 microseconds
```