### PR TITLE
Add max_iter parameter to PDIP solvers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "qpax"
-version = "0.0.9"
+version = "0.0.10"
 description = "Differentiable QP solver in JAX."
 authors = [{ name = "Kevin Tracy", email = "ktracy@cmu.edu" }]
 readme = "README.md"

--- a/qpax/diff_qp.py
+++ b/qpax/diff_qp.py
@@ -47,9 +47,12 @@ def diff_qp(Q, q, A, b, G, h, z, s, lam, nu, dl_dz):
 
 
 @jax.custom_vjp
-def solve_qp_primal(Q, q, A, b, G, h, solver_tol=1e-5, target_kappa=1e-3):
+def solve_qp_primal(Q, q, A, b, G, h, solver_tol=1e-5, target_kappa=1e-3,
+                    max_iters=30):
     # solve qp as normal and return primal solution (use any solver)
-    x, s, z, y, converged, iters1 = solve_qp(Q, q, A, b, G, h, solver_tol=solver_tol)
+    x, s, z, y, converged, iters1 = solve_qp(Q, q, A, b, G, h, 
+                                             solver_tol=solver_tol, 
+                                             max_iters=max_iters)
     return x
 
 
@@ -58,13 +61,16 @@ these two functions are only called when we diff solve_qp_x
 """
 
 
-def solve_qp_primal_forward(Q, q, A, b, G, h, solver_tol=1e-5, target_kappa=1e-3):
+def solve_qp_primal_forward(Q, q, A, b, G, h, solver_tol=1e-5, target_kappa=1e-3,
+                            max_iters=30):
     # solve qp as normal and return primal solution (use any solver)
-    x, s, z, y, converged1, iters1 = solve_qp(Q, q, A, b, G, h, solver_tol=solver_tol)
+    x, s, z, y, converged1, iters1 = solve_qp(Q, q, A, b, G, h, solver_tol=solver_tol,
+                                              max_iters=max_iters)
 
     # relax this solution by taking vanilla Newton steps on relaxed KKT
     xr, sr, zr, yr, converged2, iters2 = relax_qp(
-        Q, q, A, b, G, h, x, s, z, y, solver_tol=solver_tol, target_kappa=target_kappa
+        Q, q, A, b, G, h, x, s, z, y, solver_tol=solver_tol, target_kappa=target_kappa,
+        max_iters=max_iters
     )
 
     # return real solution x, and save the relaxed variables for backward
@@ -76,7 +82,8 @@ def solve_qp_primal_backward(res, input_grad):
     Q, q, A, b, G, h, xr, sr, zr, yr = res
 
     # return all the normal derivatives, then None's for kwargs
-    return (*diff_qp(Q, q, A, b, G, h, xr, sr, zr, yr, input_grad), None, None)
+    return (*diff_qp(Q, q, A, b, G, h, xr, sr, zr, yr, input_grad), None, None,
+            None)
 
 
 solve_qp_primal.defvjp(solve_qp_primal_forward, solve_qp_primal_backward)

--- a/qpax/elastic_qp.py
+++ b/qpax/elastic_qp.py
@@ -181,7 +181,7 @@ def while_loop_debug(cond_fun, body_fun, init_val):
     return val
 
 
-def solve_qp_elastic(Q, q, G, h, penalty, solver_tol=1e-3):
+def solve_qp_elastic(Q, q, G, h, penalty, solver_tol=1e-3, max_iters=30):
     # symmetrize Q
     Q = 0.5 * (Q + Q.T)
 
@@ -192,7 +192,7 @@ def solve_qp_elastic(Q, q, G, h, penalty, solver_tol=1e-3):
         converged = inputs[12]
         pdip_iter = inputs[13]
 
-        return jnp.logical_and(pdip_iter < 30, converged == 0)
+        return jnp.logical_and(pdip_iter < max_iters, converged == 0)
 
     converged = 0
     pdip_iter = 0
@@ -316,13 +316,14 @@ def pdip_newton_step_elastic(inputs):
     )
 
 
-def relax_qp_elastic(Q, q, G, h, penalty, x, t, s1, s2, z1, z2, solver_tol=1e-3, target_kappa=1e-3):
+def relax_qp_elastic(Q, q, G, h, penalty, x, t, s1, s2, z1, z2,
+                     solver_tol=1e-3, target_kappa=1e-3, max_iters=30):
     # continuation criteria for normal predictor-corrector
     def pc_continuation_criteria(inputs):
         converged = inputs[12]
         pdip_iter = inputs[13]
 
-        return jnp.logical_and(pdip_iter < 30, converged == 0)
+        return jnp.logical_and(pdip_iter < max_iters, converged == 0)
 
     converged = 0
     pdip_iter = 0
@@ -418,9 +419,13 @@ def diff_qp_elastic(Q, q, G, h, x, t, s1, s2, lam1, lam2, dl_dz):
 
 
 @jax.custom_vjp
-def solve_qp_elastic_primal(Q, q, G, h, penalty, solver_tol=1e-5, target_kappa=1e-3):
+def solve_qp_elastic_primal(Q, q, G, h, penalty, solver_tol=1e-5,
+                            target_kappa=1e-3,
+                            max_iters=30):
     # solve qp as normal and return primal solution (use any solver)
-    x, t, s1, s2, z1, z2, converged, pdip_iter = solve_qp_elastic(Q, q, G, h, penalty, solver_tol=solver_tol)
+    x, t, s1, s2, z1, z2, converged, pdip_iter = solve_qp_elastic(
+        Q, q, G, h, penalty, solver_tol=solver_tol, max_iters=max_iters,
+    )
 
     return x
 
@@ -430,10 +435,15 @@ these two functions are only called when we diff solve_qp_x
 """
 
 
-def solve_qp_elastic_primal_fwd(Q, q, G, h, penalty, solver_tol=1e-5, target_kappa=1e-3):
+def solve_qp_elastic_primal_fwd(Q, q, G, h, penalty, solver_tol=1e-5, 
+                                target_kappa=1e-3,
+                                 max_iters=30):
     # solve qp as normal and return primal solution (use any solver)
 
-    x, t, s1, s2, z1, z2, converged1, pdip_iter1 = solve_qp_elastic(Q, q, G, h, penalty, solver_tol=solver_tol)
+    x, t, s1, s2, z1, z2, converged1, pdip_iter1 = solve_qp_elastic(
+        Q, q, G, h, penalty, solver_tol=solver_tol,
+        max_iters=max_iters,
+    )
 
     # relax this solution by taking vanilla Newton steps on relaxed KKT
     xr, tr, s1r, s2r, z1r, z2r, converged2, pdip_iter2 = relax_qp_elastic(
@@ -450,10 +460,12 @@ def solve_qp_elastic_primal_fwd(Q, q, G, h, penalty, solver_tol=1e-5, target_kap
         z2,
         solver_tol=solver_tol,
         target_kappa=target_kappa,
+        max_iters=max_iters,
     )
 
     # return real solution x, and save the relaxed variables for backward
-    return x, (Q, q, G, h, penalty, xr, tr, s1r, s2r, z1r, z2r)
+    return x, (Q, q, G, h,
+         penalty, xr, tr, s1r, s2r, z1r, z2r)
 
 
 def solve_qp_elastic_primal_bwd(res, input_grad):
@@ -461,9 +473,10 @@ def solve_qp_elastic_primal_bwd(res, input_grad):
     Q, q, G, h, penalty, xr, tr, s1r, s2r, z1r, z2r = res
 
     # return all the normal derivatives, then None's for penalty and kwargs
-    dl_dQ, dl_dq, dl_dG, dl_dh = diff_qp_elastic(Q, q, G, h, xr, tr, s1r, s2r, z1r, z2r, input_grad)
+    dl_dQ, dl_dq, dl_dG, dl_dh = diff_qp_elastic(Q, q, G, h, xr, tr, s1r, s2r, 
+                                                 z1r, z2r, input_grad)
 
-    return (dl_dQ, dl_dq, dl_dG, dl_dh, None, None, None)
+    return (dl_dQ, dl_dq, dl_dG, dl_dh, None, None, None, None)
 
 
 solve_qp_elastic_primal.defvjp(solve_qp_elastic_primal_fwd, solve_qp_elastic_primal_bwd)

--- a/qpax/pdip.py
+++ b/qpax/pdip.py
@@ -179,7 +179,8 @@ def remove_inf_constraints(G, h):
 
 
 def solve_qp(
-    Q: jax.Array, q: jax.Array, A: jax.Array, b: jax.Array, G: jax.Array, h: jax.Array, solver_tol: float = 1e-3
+    Q: jax.Array, q: jax.Array, A: jax.Array, b: jax.Array, G: jax.Array, h: jax.Array, 
+    solver_tol: float = 1e-3, max_iters: int = 30
 ) -> Tuple[jax.Array, jax.Array, jax.Array, jax.Array, int, int]:
     """Solve a QP using a primal-dual interior point method.
 
@@ -190,6 +191,8 @@ def solve_qp(
         b: (m,) equality constraint vector
         G: (p, n) inequality constraint matrix
         h: (p,) inequality constraint vector
+        solver_tol: convergence tolerance
+        max_iters: maximum number of iterations
 
     Returns:
         x: (n,) optimal solution
@@ -229,7 +232,7 @@ def solve_qp(
         converged = inputs[11]
         pdip_iter = inputs[12]
 
-        return jnp.logical_and(pdip_iter < 30, converged == 0)
+        return jnp.logical_and(pdip_iter < max_iters, converged == 0)
 
     converged = 0
     pdip_iter = 0
@@ -306,7 +309,7 @@ def while_loop_debug(cond_fun, body_fun, init_val):
     return val
 
 
-def solve_qp_debug(Q, q, A, b, G, h, solver_tol=1e-3):
+def solve_qp_debug(Q, q, A, b, G, h, solver_tol=1e-3, max_iters=30):
     """Debug solving with verbose printing."""
     # make sure each matrix is 2D
     Q = jnp.atleast_2d(Q)
@@ -337,7 +340,7 @@ def solve_qp_debug(Q, q, A, b, G, h, solver_tol=1e-3):
         converged = inputs[11]
         pdip_iter = inputs[12]
 
-        return jnp.logical_and(pdip_iter < 30, converged == 0)
+        return jnp.logical_and(pdip_iter < max_iters, converged == 0)
 
     converged = 0
     pdip_iter = 0

--- a/qpax/pdip_relaxed.py
+++ b/qpax/pdip_relaxed.py
@@ -67,13 +67,15 @@ def pdip_newton_step(inputs):
 # 12 pdip_iter
 
 
-def relax_qp(Q, q, A, b, G, h, x, s, z, y, solver_tol=1e-5, target_kappa=1e-5):
+def relax_qp(Q, q, A, b, G, h, x, s, z, y, solver_tol=1e-5, target_kappa=1e-5,
+             max_iters=30
+    ):
     # continuation criteria for normal predictor-corrector
     def relaxed_continuation_criteria(inputs):
         converged = inputs[11]
         pdip_iter = inputs[12]
 
-        return jnp.logical_and(pdip_iter < 30, converged == 0)
+        return jnp.logical_and(pdip_iter < max_iters, converged == 0)
 
     converged = 0
     pdip_iter = 0


### PR DESCRIPTION
The maximum number of iterations in the predictor-corrector PDIP loop was previously hardcoded to 30, which is sufficient for well-conditioned problems but can cause premature termination on ill-conditioned or near-degenerate QPs. This PR exposes max_iters as a keyword argument (defaulting to 30 for backwards compatibility) across all solvers: solve_qp, solve_qp_primal, solve_qp_elastic, and solve_qp_elastic_primal, and their internal relaxation passes.

Since the solver uses jax.lax.while_loop, increasing max_iters only affects the worst-case iteration budget — well-conditioned problems will still terminate early.