### PR TITLE
Preserve solver state after convergence

### DIFF
--- a/qpax/explicit/elastic_qp.py
+++ b/qpax/explicit/elastic_qp.py
@@ -206,13 +206,14 @@ def solve_qp_elastic(Q, q, G, h, penalty, solver_tol=1e-3, max_iter=30):
             )
         )
 
+        take = converged == 0
         new_state = ElasticQPState(
-            x + alpha * dx,
-            t + alpha * dt,
-            s1 + alpha * ds1,
-            s2 + alpha * ds2,
-            z1 + alpha * dz1,
-            z2 + alpha * dz2,
+            jnp.where(take, x + alpha * dx, x),
+            jnp.where(take, t + alpha * dt, t),
+            jnp.where(take, s1 + alpha * ds1, s1),
+            jnp.where(take, s2 + alpha * ds2, s2),
+            jnp.where(take, z1 + alpha * dz1, z1),
+            jnp.where(take, z2 + alpha * dz2, z2),
         )
 
         if DEBUG_FLAG:
@@ -315,13 +316,14 @@ def relax_qp_elastic(
             )
         )
 
+        take = converged == 0
         new_state = ElasticQPState(
-            x + alpha * dx,
-            t + alpha * dt,
-            s1 + alpha * ds1,
-            s2 + alpha * ds2,
-            z1 + alpha * dz1,
-            z2 + alpha * dz2,
+            jnp.where(take, x + alpha * dx, x),
+            jnp.where(take, t + alpha * dt, t),
+            jnp.where(take, s1 + alpha * ds1, s1),
+            jnp.where(take, s2 + alpha * ds2, s2),
+            jnp.where(take, z1 + alpha * dz1, z1),
+            jnp.where(take, z2 + alpha * dz2, z2),
         )
 
         if DEBUG_FLAG:

--- a/qpax/explicit/pdip.py
+++ b/qpax/explicit/pdip.py
@@ -228,6 +228,8 @@ def solve_qp(
         qp, st, converged, pdip_iter, bad_step_seen = inputs
         Q, q, A, b, G, h = qp
         x, s, z, y = st
+        s_prev = s
+        z_prev = z
 
         # Match relax_qp's protection (pdip_relaxed.py): floor s,z so that
         # cond(H = Q + Gᵀ diag(z/s) G) stays within reach of f32 Cholesky.
@@ -283,8 +285,8 @@ def solve_qp(
         take = converged == 0
         new_state = QPState(
             jnp.where(take, x + alpha * dx, x),
-            jnp.where(take, s + alpha * ds, s),
-            jnp.where(take, z + alpha * dz, z),
+            jnp.where(take, s + alpha * ds, s_prev),
+            jnp.where(take, z + alpha * dz, z_prev),
             jnp.where(take, y + alpha * dy, y),
         )
         return (qp, new_state, converged, pdip_iter + 1, bad_step_seen)
@@ -398,6 +400,8 @@ def solve_qp_group_flags(
         ) = inputs
         Q, q, A, b, G, h = qp
         x, s, z, y = st
+        s_prev = s
+        z_prev = z
 
         # Mirror solve_qp's s,z floor so this diagnostic version follows the
         # same numerical path as production. Without it the predictor's
@@ -447,8 +451,8 @@ def solve_qp_group_flags(
         take = converged == 0
         new_state = QPState(
             jnp.where(take, x + alpha * dx, x),
-            jnp.where(take, s + alpha * ds, s),
-            jnp.where(take, z + alpha * dz, z),
+            jnp.where(take, s + alpha * ds, s_prev),
+            jnp.where(take, z + alpha * dz, z_prev),
             jnp.where(take, y + alpha * dy, y),
         )
         return (

--- a/qpax/implicit/pdip.py
+++ b/qpax/implicit/pdip.py
@@ -315,8 +315,8 @@ def solve_qp(
         y_new = jnp.where(take, y + alpha * dy, y)
         v_new = jnp.where(take, v + alpha * dv, v)
         kappa_new = jnp.where(take, kappa + alpha * dk, kappa)
-        z_new = retraction_map(v_new, kappa_new)
-        s_new = retraction_map(-v_new, kappa_new)
+        z_new = jnp.where(take, retraction_map(v_new, kappa_new), z)
+        s_new = jnp.where(take, retraction_map(-v_new, kappa_new), s)
 
         new_state = QPState(x_new, s_new, z_new, y_new)
         return (qp, new_state, converged, pdip_iter + 1)

--- a/qpax/implicit/pdip_relaxed.py
+++ b/qpax/implicit/pdip_relaxed.py
@@ -79,8 +79,8 @@ def pdip_newton_step(inputs, verbose: bool = False):
     y_new = jnp.where(take, y + alpha * dy, y)
     v_new = jnp.where(take, v + alpha * dv, v)
     kappa_new = jnp.where(take, kappa + alpha * dk, kappa)
-    z_new = retraction_map(v_new, kappa_new)
-    s_new = retraction_map(-v_new, kappa_new)
+    z_new = jnp.where(take, retraction_map(v_new, kappa_new), z)
+    s_new = jnp.where(take, retraction_map(-v_new, kappa_new), s)
 
     return (
         Q,

--- a/test/test_elastic_qp.py
+++ b/test/test_elastic_qp.py
@@ -1,6 +1,7 @@
 """Tests for the elastic QP backend dispatch."""
 
 import jax.numpy as jnp
+import numpy as np
 import pytest
 
 import qpax
@@ -17,6 +18,29 @@ def test_elastic_explicit_smoke():
     x = out[0]
     assert x.shape == (2,)
     assert jnp.all(jnp.isfinite(x))
+
+
+def test_elastic_explicit_preserves_state_on_terminal_iteration():
+    Q = jnp.eye(2, dtype=jnp.float32)
+    q = jnp.zeros(2, dtype=jnp.float32)
+    G = jnp.array([[1.0, 0.0], [0.0, 1.0]], dtype=jnp.float32)
+    h = jnp.array([1.0, 1.0], dtype=jnp.float32)
+    penalty = jnp.array(1.0, dtype=jnp.float32)
+
+    full = qpax.solve_qp_elastic(Q, q, G, h, penalty, backend="e")
+    iters = int(full[-1])
+
+    assert int(full[-2]) == 1
+    assert iters > 1
+
+    capped = qpax.solve_qp_elastic(
+        Q, q, G, h, penalty, backend="e", max_iter=iters - 1
+    )
+
+    for full_value, capped_value in zip(full[:6], capped[:6], strict=True):
+        np.testing.assert_array_equal(
+            np.asarray(full_value), np.asarray(capped_value)
+        )
 
 
 def test_elastic_implicit_raises():

--- a/test/test_qp_solver_single.py
+++ b/test/test_qp_solver_single.py
@@ -58,3 +58,47 @@ def test_qp_solver(backend):
         assert iters <= 10
 
         check_kkt_conditions(Q, q, A, b, G, h, x, s, z, y, solver_tol=solver_tol)
+
+
+@pytest.mark.parametrize(
+    ("backend", "seed", "nx", "ns", "ny"),
+    [
+        ("e", 0, 2, 2, 1),
+        ("i", 13, 4, 3, 1),
+    ],
+)
+def test_solver_preserves_state_on_terminal_iteration(backend, seed, nx, ns, ny):
+    np.random.seed(seed)
+
+    solver_tol = 1e-2
+
+    Q, q, A, b, G, h, *_ = generate_random_qp(nx, ns, ny)
+    Q = Q.astype(jnp.float32)
+    q = q.astype(jnp.float32)
+    A = A.astype(jnp.float32)
+    b = b.astype(jnp.float32)
+    G = G.astype(jnp.float32)
+    h = h.astype(jnp.float32)
+
+    full = solve_qp(Q, q, A, b, G, h, backend=backend, solver_tol=solver_tol)
+    iters = int(full[-1])
+
+    assert int(full[-2]) == 1
+    assert iters > 1
+
+    capped = solve_qp(
+        Q,
+        q,
+        A,
+        b,
+        G,
+        h,
+        backend=backend,
+        solver_tol=solver_tol,
+        max_iter=iters - 1,
+    )
+
+    for full_value, capped_value in zip(full[:4], capped[:4], strict=True):
+        np.testing.assert_array_equal(
+            np.asarray(full_value), np.asarray(capped_value)
+        )


### PR DESCRIPTION
## Summary

This PR prevents solver state from changing after a convergence check has already succeeded. The original issue was easiest to see in the implicit backend: `x` and `y` were frozen, but `s`/`z` were still recomputed through the retraction map on the terminal iteration. In float64 this is usually tiny; in float32 it can be large enough to matter for downstream batched solves or differentiable workflows.

I also checked the explicit paths. They do not use the retraction map, but they had sibling terminal-state mutations:

- the explicit PDIP path could return the internal f32 floor for `s`/`z` after convergence;
- the explicit elastic path always applied one more Newton update after convergence.

## Root Cause

In the implicit solver, the update froze `v` and `kappa` when `take == False`, but then still recomputed `s` and `z`:

```python
v_new = jnp.where(take, v + alpha * dv, v)
kappa_new = jnp.where(take, kappa + alpha * dk, kappa)
z_new = retraction_map(v_new, kappa_new)
s_new = retraction_map(-v_new, kappa_new)
```

That means a converged iterate could still be changed by one more retraction-map evaluation.

In the explicit solver, `s` and `z` are floored before the convergence check and factorization:

```python
floor = jnp.sqrt(jnp.finfo(s.dtype).eps)
s = jnp.maximum(s, floor)
z = jnp.maximum(z, floor)
```

The state update then used the floored values even when the Newton update was skipped:

```python
jnp.where(take, s + alpha * ds, s)
jnp.where(take, z + alpha * dz, z)
```

In the elastic explicit solver, the terminal Newton update was unconditional:

```python
new_state = ElasticQPState(
    x + alpha * dx,
    t + alpha * dt,
    s1 + alpha * ds1,
    s2 + alpha * ds2,
    z1 + alpha * dz1,
    z2 + alpha * dz2,
)
```

## Fix

The implicit backend now keeps the original `s`/`z` when the current iteration is already converged:

```python
z_new = jnp.where(take, retraction_map(v_new, kappa_new), z)
s_new = jnp.where(take, retraction_map(-v_new, kappa_new), s)
```

The explicit backend preserves the pre-floor state for the no-update branch:

```python
s_prev = s
z_prev = z
...
jnp.where(take, s + alpha * ds, s_prev)
jnp.where(take, z + alpha * dz, z_prev)
```

The elastic explicit backend now guards every state component with `take`:

```python
new_state = ElasticQPState(
    jnp.where(take, x + alpha * dx, x),
    jnp.where(take, t + alpha * dt, t),
    jnp.where(take, s1 + alpha * ds1, s1),
    jnp.where(take, s2 + alpha * ds2, s2),
    jnp.where(take, z1 + alpha * dz1, z1),
    jnp.where(take, z2 + alpha * dz2, z2),
)
```

## Behavior Before/After

The regression tests compare a normal converged solve against the same problem capped at `max_iter = iters - 1`. Once the solver has already converged, these two returned states should be exactly equal.

Before this PR:

- implicit `solve_qp(..., backend="i")`, f32 seeded test case: terminal `s` differed by `1.16e-10` after the extra retraction;
- explicit `solve_qp(..., backend="e")`, f32 seeded test case: terminal `z` differed by `2.44e-4` because the f32 floor leaked into the returned state;
- explicit `solve_qp_elastic(..., backend="e")`, f32 smoke case: all state components changed on the terminal iteration, with max observed difference about `6.31e-4`.

After this PR, the full converged run and the capped run return exactly equal state arrays in all added regression cases.

## Validation

```bash
uv run --with pytest pytest test/test_qp_solver_single.py test/test_elastic_qp.py -q
uv run --with pytest pytest 'test/test_relax_qp.py::test_relax_qp[i]' -q
uv run --with ruff ruff check qpax/explicit/pdip.py qpax/explicit/elastic_qp.py qpax/implicit/pdip.py qpax/implicit/pdip_relaxed.py test/test_qp_solver_single.py test/test_elastic_qp.py
```
