### PR TITLE
Fold contraints into KKT system for elastic implicit solver

### DIFF
--- a/docs/algorithm/elastic.md
+++ b/docs/algorithm/elastic.md
@@ -177,17 +177,26 @@ recovers the slack and dual directions by back-substitution.
         c1  ← ∂_κ b_κ(v1)
         c2  ← ∂_κ b_κ(v2)
 
-        # RHS aggregates
-        a1 ← rg1 + rz1 - rs1
-        a2 ← rg2 + rz2 - rs2
+        # Each constraint has an independent 3-by-3 block in
+        # (Δt_i, Δv1_i, Δv2_i), so eliminate those blocks.
+        u1 ← -rg1 + rs1 + c1 ⊙ rκ
+        u2 ← -rg2 + rs2 + c2 ⊙ rκ
+        ut ← rt + rz1 + rz2 + (c1 + c2) ⊙ rκ
+        d  ← B1⁺ B2⁻ + B2⁺ B1⁻
+        w  ← diag(B1⁺ B2⁺) ⊘ diag(d)
+        o2 ← B2⁺ d⁻¹ (B1⁻ ut + B1⁺ (u1 - u2))
 
-        # Reduced KKT system in (Δx, Δt, Δv1, Δv2)
-        ┌ Q - GᵀG   Gᵀ    0     Gᵀ  ┐ ┌ Δx  ┐   ┌ -rx + Gᵀ a2        ┐
-        │ G        -2I   -I    -I   │ │ Δt  │ = │ -rt - a1 - a2      │
-        │ 0        -I   -B1⁻   0    │ │ Δv1 │   │ -rg1 + rs1 + c1 rκ │
-        └ G        -I    0    -B2⁻  ┘ └ Δv2 ┘   └ -rg2 + rs2 + c2 rκ ┘
+        # Factor and solve an n-by-n primal system.
+        H   ← Q + Gᵀ diag(w) G
+        L_H ← factor(H)
+        Δx  ← solve(L_H, -rx + Gᵀ (rz2 + c2 ⊙ rκ - o2))
 
-        Solve the reduced system for (Δx, Δt, Δv1, Δv2)
+        # Elementwise back-substitution
+        y   ← G Δx
+        Δt  ← (B2⁺ B1⁻ y - B1⁻ B2⁻ ut
+               - B1⁺ B2⁻ u1 - B2⁺ B1⁻ u2) ⊘ d
+        Δv1 ← (B2⁻ ut - B2⁺ (y + u1 - u2)) ⊘ d
+        Δv2 ← (B1⁻ ut + B1⁺ (y + u1 - u2)) ⊘ d
 
         # Back-substitution
         Δκ  ← -rκ

--- a/qpax/elastic_qp.py
+++ b/qpax/elastic_qp.py
@@ -1,8 +1,7 @@
 """Top-level elastic-QP dispatcher.
 
 Routes ``solve_qp_elastic`` and ``solve_qp_elastic_primal`` to either the
-explicit (``backend="e"``) or implicit (``backend="i"``) backend. The
-implicit backend currently raises ``NotImplementedError``.
+explicit (``backend="e"``) or implicit (``backend="i"``) backend.
 """
 
 from typing import Any
@@ -31,8 +30,8 @@ def solve_qp_elastic(
         G: ``(p, n)`` inequality constraint matrix.
         h: ``(p,)`` inequality constraint RHS.
         penalty: per-unit cost of slack on each inequality.
-        backend: only ``"e"`` is supported; ``"i"`` raises ``NotImplementedError``.
-        **kwargs: forwarded to the explicit backend (e.g. ``solver_tol``,
+        backend: ``"e"`` for explicit PDIP or ``"i"`` for implicit PDIP.
+        **kwargs: forwarded to the selected backend (e.g. ``solver_tol`` and
             ``max_iter``).
     """
     if backend == "e":
@@ -60,8 +59,8 @@ def solve_qp_elastic_primal(
         G: ``(p, n)`` inequality constraint matrix.
         h: ``(p,)`` inequality constraint RHS.
         penalty: per-unit cost of slack on each inequality.
-        backend: only ``"e"`` is supported; ``"i"`` raises ``NotImplementedError``.
-        **kwargs: forwarded to the explicit backend.
+        backend: ``"e"`` for explicit PDIP or ``"i"`` for implicit PDIP.
+        **kwargs: forwarded to the selected backend.
     """
     if backend == "e":
         return _explicit.solve_qp_elastic_primal(Q, q, G, h, penalty, **kwargs)

--- a/qpax/implicit/elastic_qp.py
+++ b/qpax/implicit/elastic_qp.py
@@ -39,6 +39,16 @@ class ElasticQPState(NamedTuple):
     z2: jax.Array
 
 
+class FoldedElasticKKT(NamedTuple):
+    """Factorization and diagonal terms for the folded elastic KKT solve."""
+
+    B1n: jax.Array
+    B2n: jax.Array
+    denominator: jax.Array
+    lu: jax.Array
+    piv: jax.Array
+
+
 # ------------------------------ initialization ------------------------------ #
 
 
@@ -47,7 +57,7 @@ def solve_init_elastic_ls(qp: ElasticQPData, solver: LinearSolver):
     Q, q, G, h, penalty = qp
     ns = len(h)
     r1 = -q
-    r2 = penalty * jnp.ones(ns)
+    r2 = penalty * jnp.ones(ns, dtype=Q.dtype)
     r4 = h
 
     L_H = _factor_init(Q + 0.5 * G.T @ G, solver)
@@ -91,14 +101,15 @@ def initialize_elastic(
 
 
 def factorize_elastic_implicit_kkt(Q, G, v1, v2, kappa):
-    """Factorize the reduced 4-block implicit elastic KKT system with LU.
+    """Factorize the primal Schur complement of the elastic KKT system.
 
-    Builds and factors
-        [ Q - GᵀG   Gᵀ    0       Gᵀ    ]
-        [ G        -2I   -I      -I     ]
-        [ 0        -I    -B1⁻     0     ]
-        [ G        -I     0      -B2⁻   ]
-    where B_k⁻ = diag(b_κ'(-v_k)).
+    The ``(dt, dv1, dv2)`` equations are independent for every constraint.
+    Eliminating those variables leaves the ``len(q)`` square system
+
+        H = Q + G.T @ diag(B1p * B2p / d) @ G,
+
+    where ``d = B1p * B2n + B2p * B1n``. This avoids factoring the
+    ``len(q) + 3 * len(h)`` square block used by the unreduced formulation.
     """
     B1n_vec = derivative_retraction_map(-v1, kappa)
     B2n_vec = derivative_retraction_map(-v2, kappa)
@@ -107,25 +118,17 @@ def factorize_elastic_implicit_kkt(Q, G, v1, v2, kappa):
     c1_vec = derivative_retraction_map_kappa(v1, kappa)
     c2_vec = derivative_retraction_map_kappa(v2, kappa)
 
-    nx = G.shape[1]
-    nz = G.shape[0]
-    Iz = jnp.eye(nz, dtype=Q.dtype)
-    Zz = jnp.zeros((nz, nz), dtype=Q.dtype)
-    Zxz = jnp.zeros((nx, nz), dtype=Q.dtype)
-    Zzx = jnp.zeros((nz, nx), dtype=Q.dtype)
-
-    GtG = jnp.matmul(G.T, G, precision=jax.lax.Precision.HIGHEST)
-    J = jnp.block(
-        [
-            [Q - GtG, G.T, Zxz, G.T],
-            [G, -2.0 * Iz, -Iz, -Iz],
-            [Zzx, -Iz, -jnp.diag(B1n_vec), Zz],
-            [G, -Iz, Zz, -jnp.diag(B2n_vec)],
-        ]
+    denominator = B1p_vec * B2n_vec + B2p_vec * B1n_vec
+    schur_diagonal = B1p_vec * B2p_vec / denominator
+    H = Q + jnp.matmul(
+        G.T,
+        schur_diagonal[:, None] * G,
+        precision=jax.lax.Precision.HIGHEST,
     )
-    L_J = jsp.linalg.lu_factor(J)
+    lu, piv = jsp.linalg.lu_factor(H)
+    factor = FoldedElasticKKT(B1n_vec, B2n_vec, denominator, lu, piv)
 
-    return B1p_vec, B2p_vec, c1_vec, c2_vec, L_J
+    return B1p_vec, B2p_vec, c1_vec, c2_vec, factor
 
 
 def solve_elastic_implicit_kkt_rhs(
@@ -134,7 +137,7 @@ def solve_elastic_implicit_kkt_rhs(
     B2p_vec,
     c1_vec,
     c2_vec,
-    L_J,
+    factor,
     rx,
     rt,
     rg1,
@@ -145,31 +148,33 @@ def solve_elastic_implicit_kkt_rhs(
     rs2,
     rk,
 ):
-    """Solve the implicit elastic KKT system given a pre-computed LU factorization."""
-    nx = G.shape[1]
-    nz = G.shape[0]
+    """Solve a folded implicit elastic KKT system and back-substitute."""
+    B1n_vec, B2n_vec, denominator, lu, piv = factor
 
-    a1 = rg1 + rz1 - rs1
-    a2 = rg2 + rz2 - rs2
+    # Right-hand sides for the two primal constraints and t stationarity.
+    R3 = -rg1 + rs1 + c1_vec * rk
+    R4 = -rg2 + rs2 + c2_vec * rk
+    St = rt + rz1 + rz2 + (c1_vec + c2_vec) * rk
 
-    rhs = jnp.concatenate(
-        [
-            rx - G.T @ a2,
-            rt + a1 + a2,
-            rg1 - rs1 - c1_vec * rk,
-            rg2 - rs2 - c2_vec * rk,
-        ]
-    )
-    sol = jsp.linalg.lu_solve(L_J, -rhs)
+    # The part of B2p * dv2 that is independent of G @ dx.
+    dz2_offset = (B2p_vec / denominator) * (B1n_vec * St + B1p_vec * (R3 - R4))
+    rhs = -rx + G.T @ (rz2 + c2_vec * rk - dz2_offset)
+    dx = jsp.linalg.lu_solve((lu, piv), rhs)
 
-    dx = sol[:nx]
-    dt = sol[nx : nx + nz]
-    dv1 = sol[nx + nz : nx + 2 * nz]
-    dv2 = sol[nx + 2 * nz :]
+    Gdx = G @ dx
+    dt = (
+        B2p_vec * B1n_vec * Gdx
+        - B1n_vec * B2n_vec * St
+        - B1p_vec * B2n_vec * R3
+        - B2p_vec * B1n_vec * R4
+    ) / denominator
+    common = Gdx + R3 - R4
+    dv1 = (B2n_vec * St - B2p_vec * common) / denominator
+    dv2 = (B1n_vec * St + B1p_vec * common) / denominator
 
     dk = -rk
     ds1 = -rg1 + dt
-    ds2 = -rg2 - G @ dx + dt
+    ds2 = -rg2 - Gdx + dt
     dz1 = -rz1 + B1p_vec * dv1 - c1_vec * rk
     dz2 = -rz2 + B2p_vec * dv2 - c2_vec * rk
 
@@ -212,7 +217,7 @@ def solve_qp_elastic(
         kappa = jnp.maximum((jnp.dot(s1, z1) + jnp.dot(s2, z2)) / (2 * m), 1e-14)
 
         r1 = Q @ x + q + G.T @ z2
-        r2 = -z1 - z2 + penalty * jnp.ones(m)
+        r2 = -z1 - z2 + penalty * jnp.ones(m, dtype=Q.dtype)
         r3 = s1 * z1
         r4 = s2 * z2
         r5 = -t + s1
@@ -226,7 +231,7 @@ def solve_qp_elastic(
         rz2 = z2 - retraction_map(v2, kappa)
         rs2 = s2 - retraction_map(-v2, kappa)
 
-        B1p, B2p, c1, c2, L_J = factorize_elastic_implicit_kkt(Q, G, v1, v2, kappa)
+        B1p, B2p, c1, c2, factor = factorize_elastic_implicit_kkt(Q, G, v1, v2, kappa)
 
         kappa_target = sigma * kappa
         rk = kappa - kappa_target
@@ -237,7 +242,7 @@ def solve_qp_elastic(
             B2p,
             c1,
             c2,
-            L_J,
+            factor,
             r1,
             r2,
             r5,
@@ -353,8 +358,7 @@ def pdip_newton_step_elastic(inputs, verbose: bool = False):
         _B2p_prev,
         _c1_prev,
         _c2_prev,
-        _lu_prev,
-        _piv_prev,
+        _factor_prev,
     ) = inputs
 
     m = len(h)
@@ -363,7 +367,7 @@ def pdip_newton_step_elastic(inputs, verbose: bool = False):
     kappa = jnp.maximum((jnp.dot(s1, z1) + jnp.dot(s2, z2)) / (2 * m), 1e-14)
 
     r1 = Q @ x + q + G.T @ z2
-    r2 = -z1 - z2 + penalty * jnp.ones(m)
+    r2 = -z1 - z2 + penalty * jnp.ones(m, dtype=Q.dtype)
     r3 = s1 * z1 - target_kappa
     r4 = s2 * z2 - target_kappa
     r5 = -t + s1
@@ -377,7 +381,7 @@ def pdip_newton_step_elastic(inputs, verbose: bool = False):
     rz2 = z2 - retraction_map(v2, kappa)
     rs2 = s2 - retraction_map(-v2, kappa)
 
-    B1p, B2p, c1, c2, L_J = factorize_elastic_implicit_kkt(Q, G, v1, v2, kappa)
+    B1p, B2p, c1, c2, factor = factorize_elastic_implicit_kkt(Q, G, v1, v2, kappa)
 
     rk = kappa - target_kappa
     dx, dt, ds1, ds2, dz1, dz2, dv1, dv2, dk = solve_elastic_implicit_kkt_rhs(
@@ -386,7 +390,7 @@ def pdip_newton_step_elastic(inputs, verbose: bool = False):
         B2p,
         c1,
         c2,
-        L_J,
+        factor,
         r1,
         r2,
         r5,
@@ -454,8 +458,7 @@ def pdip_newton_step_elastic(inputs, verbose: bool = False):
         B2p,
         c1,
         c2,
-        L_J[0],
-        L_J[1],
+        factor,
     )
 
 
@@ -478,6 +481,8 @@ def relax_qp_elastic(
     verbose: bool = False,
 ):
     """Relaxed elastic solve that also returns the last Newton-step factorization."""
+    solver_tol = jnp.asarray(solver_tol, dtype=Q.dtype)
+    target_kappa = jnp.asarray(target_kappa, dtype=Q.dtype)
 
     def relaxed_continuation_criteria(inputs):
         converged = inputs[12]
@@ -485,7 +490,14 @@ def relax_qp_elastic(
         return jnp.logical_and(pdip_iter < max_iter, converged == 0)
 
     nz = G.shape[0]
-    dim = G.shape[1] + 3 * nz
+    nx = G.shape[1]
+    empty_factor = FoldedElasticKKT(
+        jnp.zeros(nz, dtype=Q.dtype),
+        jnp.zeros(nz, dtype=Q.dtype),
+        jnp.ones(nz, dtype=Q.dtype),
+        jnp.zeros((nx, nx), dtype=Q.dtype),
+        jnp.zeros(nx, dtype=jnp.int32),
+    )
 
     init_inputs = (
         Q,
@@ -507,8 +519,7 @@ def relax_qp_elastic(
         jnp.zeros(nz, dtype=Q.dtype),
         jnp.zeros(nz, dtype=Q.dtype),
         jnp.zeros(nz, dtype=Q.dtype),
-        jnp.zeros((dim, dim), dtype=Q.dtype),
-        jnp.zeros(dim, dtype=jnp.int32),
+        empty_factor,
     )
 
     if verbose:
@@ -541,7 +552,7 @@ def relax_qp_elastic(
     converged = outputs[12]
     pdip_iter = outputs[13]
     B1p, B2p, c1, c2 = outputs[15:19]
-    L_J = outputs[19], outputs[20]
+    L_J = outputs[19]
 
     if verbose:
         cost = 0.5 * x_rlx @ Q @ x_rlx + q @ x_rlx + penalty * jnp.sum(t_rlx)

--- a/test/test_elastic_qp.py
+++ b/test/test_elastic_qp.py
@@ -1,10 +1,15 @@
-"""Tests for the elastic QP backend dispatch."""
+"""Tests for the elastic QP backends."""
 
+import jax
 import jax.numpy as jnp
 import numpy as np
 import pytest
 
 import qpax
+from qpax.implicit.elastic_qp import (
+    factorize_elastic_implicit_kkt,
+    solve_elastic_implicit_kkt_rhs,
+)
 
 
 @pytest.mark.parametrize("backend", ["e", "i"])
@@ -42,3 +47,138 @@ def test_elastic_preserves_state_on_terminal_iteration(backend):
 
     for full_value, capped_value in zip(full[:6], capped[:6], strict=True):
         np.testing.assert_array_equal(np.asarray(full_value), np.asarray(capped_value))
+
+
+def test_implicit_elastic_folded_kkt_matches_dense_system():
+    """The n-by-n Schur solve must match the former (n + 3p)-block solve."""
+    n, p = 5, 17
+    keys = iter(jax.random.split(jax.random.PRNGKey(11), 13))
+
+    R = jax.random.normal(next(keys), (n, n))
+    Q = R.T @ R + jnp.eye(n)
+    G = jax.random.normal(next(keys), (p, n))
+    v1 = jax.random.normal(next(keys), (p,))
+    v2 = jax.random.normal(next(keys), (p,))
+    kappa = jnp.float32(0.2)
+    residuals = (
+        jax.random.normal(next(keys), (n,)),
+        *(jax.random.normal(next(keys), (p,)) for _ in range(7)),
+        jnp.float32(0.07),
+    )
+
+    B1p, B2p, c1, c2, factor = factorize_elastic_implicit_kkt(Q, G, v1, v2, kappa)
+    folded = solve_elastic_implicit_kkt_rhs(G, B1p, B2p, c1, c2, factor, *residuals)
+
+    rx, rt, rg1, rg2, rz1, rs1, rz2, rs2, rk = residuals
+    a1 = rg1 + rz1 - rs1
+    a2 = rg2 + rz2 - rs2
+    zeros_pp = jnp.zeros((p, p), dtype=Q.dtype)
+    zeros_np = jnp.zeros((n, p), dtype=Q.dtype)
+    zeros_pn = jnp.zeros((p, n), dtype=Q.dtype)
+    eye_p = jnp.eye(p, dtype=Q.dtype)
+    dense_kkt = jnp.block(
+        [
+            [Q - G.T @ G, G.T, zeros_np, G.T],
+            [G, -2.0 * eye_p, -eye_p, -eye_p],
+            [zeros_pn, -eye_p, -jnp.diag(factor.B1n), zeros_pp],
+            [G, -eye_p, zeros_pp, -jnp.diag(factor.B2n)],
+        ]
+    )
+    dense_rhs = jnp.concatenate(
+        [
+            rx - G.T @ a2,
+            rt + a1 + a2,
+            rg1 - rs1 - c1 * rk,
+            rg2 - rs2 - c2 * rk,
+        ]
+    )
+    dense_solution = jnp.linalg.solve(dense_kkt, -dense_rhs)
+    dx = dense_solution[:n]
+    dt = dense_solution[n : n + p]
+    dv1 = dense_solution[n + p : n + 2 * p]
+    dv2 = dense_solution[n + 2 * p :]
+    dense = (
+        dx,
+        dt,
+        -rg1 + dt,
+        -rg2 - G @ dx + dt,
+        -rz1 + B1p * dv1 - c1 * rk,
+        -rz2 + B2p * dv2 - c2 * rk,
+        dv1,
+        dv2,
+        -rk,
+    )
+
+    assert factor.lu.shape == (n, n)
+    assert dense_kkt.shape == (n + 3 * p, n + 3 * p)
+    for folded_value, dense_value in zip(folded, dense, strict=True):
+        np.testing.assert_allclose(folded_value, dense_value, rtol=1e-3, atol=1e-3)
+
+
+def _known_solution_elastic_qp(n, p):
+    keys = jax.random.split(jax.random.PRNGKey(1000 + p), 4)
+    R = jax.random.normal(keys[0], (n, n), dtype=jnp.float32)
+    Q = R.T @ R / n + jnp.eye(n, dtype=jnp.float32)
+    x = 0.2 * jax.random.normal(keys[1], (n,), dtype=jnp.float32)
+    G = jax.random.normal(keys[2], (p, n), dtype=jnp.float32) / jnp.sqrt(n)
+    magnitude = 0.25 + 0.5 * jax.random.uniform(keys[3], (p,), dtype=jnp.float32)
+    violated = jnp.arange(p) % 2 == 0
+    t = jnp.where(violated, magnitude, 0.0)
+    s2 = jnp.where(violated, 0.0, magnitude)
+    penalty = jnp.float32(1.0)
+    z2 = jnp.where(violated, penalty, 0.0)
+    h = G @ x - t + s2
+    q = -Q @ x - G.T @ z2
+    return Q, q, G, h, penalty, x
+
+
+@pytest.mark.parametrize("n_constraints", [1, 50, 500])
+def test_implicit_elastic_f32_constraint_scaling_accuracy(n_constraints):
+    Q, q, G, h, penalty, expected_x = _known_solution_elastic_qp(35, n_constraints)
+    x, t, s1, s2, z1, z2, converged, _ = qpax.solve_qp_elastic(
+        Q,
+        q,
+        G,
+        h,
+        penalty,
+        backend="i",
+        solver_tol=1e-3,
+        max_iter=50,
+    )
+
+    residual = jnp.concatenate(
+        (
+            Q @ x + q + G.T @ z2,
+            -z1 - z2 + penalty,
+            s1 * z1,
+            s2 * z2,
+            -t + s1,
+            G @ x - t + s2 - h,
+        )
+    )
+    assert int(converged) == 1
+    assert float(jnp.linalg.norm(residual, ord=jnp.inf)) < 1e-3
+    np.testing.assert_allclose(x, expected_x, rtol=5e-3, atol=3e-3)
+
+
+def test_implicit_elastic_folded_factor_supports_backward_pass():
+    Q, q, G, h, penalty, _ = _known_solution_elastic_qp(5, 10)
+
+    def loss(q_value):
+        x = qpax.solve_qp_elastic_primal(
+            Q,
+            q_value,
+            G,
+            h,
+            penalty,
+            backend="i",
+            solver_tol=1e-3,
+            target_kappa=1e-3,
+            max_iter=50,
+        )
+        return jnp.sum(x * x)
+
+    gradient = jax.jit(jax.grad(loss))(q)
+    assert gradient.shape == q.shape
+    assert gradient.dtype == q.dtype
+    assert bool(jnp.all(jnp.isfinite(gradient)))


### PR DESCRIPTION
Hey Jon, 

Great seeing you at ICRA  :D

I was messing around with the implicit backend and was thinking about adding an option in CBFpy to specify this for running on GPU. But, CBFpy really relies on the good constraint scaling performance of Kevin's elastic explicit solver, so I was curious to see if it was also possible to fold the constraints into the KKT system for the implicit backend.

Turns out that maybe this is possible? With the help of GPT 5.6 Sol xhigh (I can't take full credit for this, haha) and a bunch of back and forth prompting we came up with this. Some preliminary tests look good, but I might be missing something fundamental about the limitations of the implicit backend and single precision. Wondering if you have any thoughts?

If all looks good, I'll integrate this into my other packages! Very excited to run more qpax on GPU

- Dan