### PR TITLE
Flooring and regularization fallback for NaN prevention in f32 implicit elastic solver

### DIFF
--- a/qpax/implicit/elastic_qp.py
+++ b/qpax/implicit/elastic_qp.py
@@ -222,7 +222,13 @@ def solve_qp_elastic(
         m = len(h)
         v1 = z1 - s1
         v2 = z2 - s2
-        kappa = jnp.maximum((jnp.dot(s1, z1) + jnp.dot(s2, z2)) / (2 * m), 1e-14)
+
+        # Floor kappa similar to the handling in the explicit backend
+        # to prevent nans under Cholesky float32
+        eps = jnp.finfo(Q.dtype).eps
+        # Rough order-of-magnitude clamping for the floor
+        kappa_floor = jnp.clip(0.05 * params.tol, 10 * eps, jnp.sqrt(eps))
+        kappa = jnp.maximum((jnp.dot(s1, z1) + jnp.dot(s2, z2)) / (2 * m), kappa_floor)
 
         r1 = Q @ x + q + G.T @ z2
         r2 = -z1 - z2 + penalty * jnp.ones(m, dtype=Q.dtype)
@@ -241,7 +247,8 @@ def solve_qp_elastic(
 
         B1p, B2p, c1, c2, factor = factorize_elastic_implicit_kkt(Q, G, v1, v2, kappa)
 
-        kappa_target = sigma * kappa
+        # Floor the target as well to prevent undershoot
+        kappa_target = jnp.maximum(sigma * kappa, kappa_floor)
         rk = kappa - kappa_target
 
         dx, dt, ds1, ds2, dz1, dz2, dv1, dv2, dk = solve_elastic_implicit_kkt_rhs(
@@ -297,6 +304,23 @@ def solve_qp_elastic(
         s1_new = jnp.where(take, retraction_map(-v1_new, kappa_new), s1)
         z2_new = jnp.where(take, retraction_map(v2_new, kappa_new), z2)
         s2_new = jnp.where(take, retraction_map(-v2_new, kappa_new), s2)
+
+        # Similar non-finite guard to explicit backend --
+        # don't let possible blowups or nans enter the state
+        step_finite = jnp.all(
+            jnp.stack(
+                [
+                    jnp.all(jnp.isfinite(a))
+                    for a in (x_new, t_new, s1_new, s2_new, z1_new, z2_new)
+                ]
+            )
+        )
+        x_new = jnp.where(step_finite, x_new, x)
+        t_new = jnp.where(step_finite, t_new, t)
+        s1_new = jnp.where(step_finite, s1_new, s1)
+        s2_new = jnp.where(step_finite, s2_new, s2)
+        z1_new = jnp.where(step_finite, z1_new, z1)
+        z2_new = jnp.where(step_finite, z2_new, z2)
 
         new_state = ElasticQPState(x_new, t_new, s1_new, s2_new, z1_new, z2_new)
         return (qp, new_state, converged, pdip_iter + 1)
@@ -372,7 +396,10 @@ def pdip_newton_step_elastic(inputs, verbose: bool = False):
     m = len(h)
     v1 = z1 - s1
     v2 = z2 - s2
-    kappa = jnp.maximum((jnp.dot(s1, z1) + jnp.dot(s2, z2)) / (2 * m), 1e-14)
+
+    # Similar flooring strategy as in solve_qp_elastic but without scaling with tol
+    kappa_floor = jnp.maximum(jnp.sqrt(jnp.finfo(Q.dtype).eps), 1e-14)
+    kappa = jnp.maximum((jnp.dot(s1, z1) + jnp.dot(s2, z2)) / (2 * m), kappa_floor)
 
     r1 = Q @ x + q + G.T @ z2
     r2 = -z1 - z2 + penalty * jnp.ones(m, dtype=Q.dtype)

--- a/qpax/implicit/elastic_qp.py
+++ b/qpax/implicit/elastic_qp.py
@@ -132,8 +132,17 @@ def factorize_elastic_implicit_kkt(Q, G, v1, v2, kappa):
         schur_diagonal[:, None] * G,
         precision=jax.lax.Precision.HIGHEST,
     )
-    # H is SPD by construction; Cholesky is exact-shape and ~2x cheaper than LU.
+    # H is SPD but float32 cholesky can still fail (likely, due to rounding
+    # errors leading to taking a sqrt of a negative pivot)
+    # So, at the expense of one more factorization, use the unmodified
+    # factorization if nan-free, otherwise use a regularized version
     chol, _ = jsp.linalg.cho_factor(H, lower=False)
+    n = H.shape[0]
+    delta = 10 * n * jnp.finfo(H.dtype).eps * jnp.max(jnp.diagonal(H))
+    chol_shifted, _ = jsp.linalg.cho_factor(
+        H + delta * jnp.eye(n, dtype=H.dtype), lower=False
+    )
+    chol = jnp.where(jnp.all(jnp.isfinite(chol)), chol, chol_shifted)
     factor = FoldedElasticKKT(B1n_vec, B2n_vec, denominator, chol)
 
     return B1p_vec, B2p_vec, c1_vec, c2_vec, factor

--- a/test/test_elastic_qp.py
+++ b/test/test_elastic_qp.py
@@ -8,6 +8,7 @@ import pytest
 import qpax
 from qpax.implicit.elastic_qp import (
     factorize_elastic_implicit_kkt,
+    relax_qp_elastic,
     solve_elastic_implicit_kkt_rhs,
 )
 
@@ -274,6 +275,69 @@ def test_implicit_elastic_f32_constraint_scaling_accuracy(n_constraints):
     assert int(converged) == 1
     assert float(jnp.linalg.norm(residual, ord=jnp.inf)) < 1e-3
     np.testing.assert_allclose(x, expected_x, rtol=5e-3, atol=3e-3)
+
+
+def _ill_conditioned_elastic_batch(batch, n, p, seed):
+    """Elastic QPs whose folded Schur complement stresses f32 Cholesky.
+
+    A large penalty puts ~penalty^2 / kappa on the Schur diagonal at active
+    constraints, driving cond(H) toward the f32 Cholesky limit ~1/(n*eps).
+    A quarter of the rows are infeasible at the seed point so the elastic
+    slack activates and both dual pairs sit near the penalty.
+    """
+    rng = np.random.default_rng(seed)
+    M = rng.normal(size=(batch, n, n))
+    Q = np.einsum("bij,bik->bjk", M, M) / n + 1e-1 * np.eye(n)[None]
+    q = rng.normal(size=(batch, n))
+    G = rng.normal(size=(batch, p, n)) * 0.5
+    x0 = rng.normal(size=(batch, n)) * 0.5
+    slack = rng.uniform(0.1, 1.0, size=(batch, p))
+    slack[:, : max(1, p // 4)] *= -1.0
+    h = np.einsum("bij,bj->bi", G, x0) + slack
+    penalty = jnp.float32(100.0)
+    to_f32 = lambda a: jnp.asarray(a, dtype=jnp.float32)  # noqa: E731
+    return to_f32(Q), to_f32(q), to_f32(G), to_f32(h), penalty
+
+
+def test_implicit_elastic_f32_ill_conditioned_batch_stays_finite():
+    """Batched f32 solve + relax must not emit NaN near the Cholesky limit.
+
+    Regression test for two f32 failure modes in the implicit elastic backend:
+
+    1. kappa collapsing below f32 epsilon under vmap
+    2. cho_factor producing NaN on an SPD-but-ill-conditioned H
+    """
+    Q, q, G, h, penalty = _ill_conditioned_elastic_batch(128, 29, 96, seed=7)
+
+    def pipeline(Qi, qi, Gi, hi):
+        out = qpax.solve_qp_elastic(
+            Qi, qi, Gi, hi, penalty, backend="i", solver_tol=1e-3, max_iter=50
+        )
+        x, t, s1, s2, z1, z2 = out[:6]
+        relaxed = relax_qp_elastic(
+            Qi,
+            qi,
+            Gi,
+            hi,
+            penalty,
+            x,
+            t,
+            s1,
+            s2,
+            z1,
+            z2,
+            solver_tol=1e-3,
+            target_kappa=1e-3,
+            max_iter=50,
+        )
+        return out[0], out[6], relaxed[0], relaxed[11]
+
+    x_fwd, conv_fwd, x_rlx, conv_rlx = jax.jit(jax.vmap(pipeline))(Q, q, G, h)
+
+    assert bool(jnp.all(jnp.isfinite(x_fwd)))
+    assert bool(jnp.all(jnp.isfinite(x_rlx)))
+    assert float(jnp.mean(conv_fwd)) >= 0.98
+    assert float(jnp.mean(conv_rlx)) >= 0.99
 
 
 def test_implicit_elastic_folded_factor_supports_backward_pass():


### PR DESCRIPTION
Hey Jon, 

Thanks for merging the updates to the implicit elastic backend! With the new Cholesky factorization though, I was seeing some NaNs in some of the tests I was running. I remembered in the explicit backend there are some floors around s/z to prevent bad conditioning in Cholesky, so I believe this is an equivalent solution for the implicit backend (floors on kappa instead). Even with the floor on kappa, I was still seeing some nans pop up, so I tried adding a regularization term to H. Just adding this regularization term led to really poor convergence, but it does seem that a useful strategy is to compute 2 factorizations and only fall back to the regularized form if the nominal version produces nans. This does cost 1 extra factorization though, but it doesn't seem to be that costly

Let me know if you have any thoughts! I was focusing on the elastic solver so I'm not sure if similar problems exist anywhere else