### PR TITLE
Fix incorrect derivatives w.r.t inequality matrix in explicit backend

### DIFF
--- a/docs/algorithm/elastic.md
+++ b/docs/algorithm/elastic.md
@@ -295,17 +295,12 @@ point to compute gradients.
                                                    κ_relax, ∇xl; K̃)
 
         r ← (-∇xl, 0, 0, 0, 0, 0)
-        (dx, dt, ds1, ds2, dz1, dz2) ← solve_kkt(K̃, r, κ_relax)
-
-        dz_aug ← (dx, dt)
-        z_aug  ← (x,  t)
-        dλ     ← (dz1, dz2) / (z1, z2)
-        λ      ← (z1, z2)
+        (dx, dt, ds1, ds2, dẑ1, dẑ2) ← solve_kkt(K̃, r, κ_relax)
 
         ∇Ql ← (dx xᵀ + x dxᵀ) / 2
         ∇ql ← dx
-        ∇Gl ← dz2 xᵀ + z2 dxᵀ
-        ∇hl ← -z2 ⊙ dλ_2
+        ∇Gl ← dẑ2 xᵀ + z2 dxᵀ
+        ∇hl ← -dẑ2
 
         return ∇Ql, ∇ql, ∇Gl, ∇hl
 

--- a/qpax/explicit/diff_qp.py
+++ b/qpax/explicit/diff_qp.py
@@ -5,14 +5,14 @@ from qpax.explicit.pdip import factorize_kkt, solve_kkt_rhs, solve_qp
 from qpax.explicit.pdip_relaxed import relax_qp
 
 
-def optnet_derivatives(dz, dlam, dnu, z, lam, nu):
+def optnet_derivatives(dz, dlam_tilde, dnu, z, lam, nu):
     dl_dQ = 0.5 * (jnp.outer(dz, z) + jnp.outer(z, dz))
     dl_dA = jnp.outer(dnu, z) + jnp.outer(nu, dz)
-    dl_dG = jnp.diag(lam) @ (jnp.outer(dlam, z) + jnp.outer(lam, dz))
+    dl_dG = jnp.outer(dlam_tilde, z) + jnp.outer(lam, dz)
 
     dl_dq = dz
     dl_db = -dnu
-    dl_dh = -lam * dlam
+    dl_dh = -dlam_tilde
 
     return dl_dQ, dl_dq, dl_dA, dl_db, dl_dG, dl_dh
 
@@ -38,10 +38,7 @@ def diff_qp(Q, q, A, b, G, h, z, s, lam, nu, dl_dz):
         jnp.zeros(nnu, dtype=cotangent_dtype),
     )
 
-    # recover real dlam from our modified (symmetrized) KKT system
-    dlam = dlam_tilde / lam
-
-    return optnet_derivatives(dz, dlam, dnu, z, lam, nu)
+    return optnet_derivatives(dz, dlam_tilde, dnu, z, lam, nu)
 
 
 @jax.custom_vjp

--- a/qpax/explicit/elastic_qp.py
+++ b/qpax/explicit/elastic_qp.py
@@ -386,12 +386,12 @@ def relax_qp_elastic(
     return x_rlx, t_rlx, s1_rlx, s2_rlx, z1_rlx, z2_rlx, converged, pdip_iter
 
 
-def optnet_derivatives_elastic(dz, dlam, z, lam):
+def optnet_derivatives_elastic(dz, dlam_tilde, z, lam):
     dl_dQ = 0.5 * (jnp.outer(dz, z) + jnp.outer(z, dz))
-    dl_dG = jnp.diag(lam) @ (jnp.outer(dlam, z) + jnp.outer(lam, dz))  # TODO
+    dl_dG = jnp.outer(dlam_tilde, z) + jnp.outer(lam, dz)
 
     dl_dq = dz
-    dl_dh = -lam * dlam
+    dl_dh = -dlam_tilde
 
     return dl_dQ, dl_dq, dl_dG, dl_dh
 
@@ -410,9 +410,9 @@ def diff_qp_elastic(Q, q, G, h, x, t, s1, s2, lam1, lam2, dl_dz):
     lam = jnp.concatenate((lam1, lam2))
     dlam_tilde = jnp.concatenate((dlam1, dlam2))
 
-    dlam = dlam_tilde / lam
-
-    dl_dQ, dl_dq, dl_dG, dl_dh = optnet_derivatives_elastic(dz, dlam, z, lam)
+    dl_dQ, dl_dq, dl_dG, dl_dh = optnet_derivatives_elastic(
+        dz, dlam_tilde, z, lam
+    )
 
     dl_dQ = dl_dQ[:nz, :nz]
     dl_dq = dl_dq[:nz]

--- a/test/test_elastic_qp.py
+++ b/test/test_elastic_qp.py
@@ -28,8 +28,9 @@ def test_elastic_smoke(backend):
     assert jnp.all(jnp.isfinite(x))
     assert int(out[-2]) == 1
 
+
 @pytest.mark.parametrize("backend", ["e", "i"])
-def test_elastic_inequality_matrix_derivative(backend):
+def test_elastic_inequality_parameter_derivatives(backend):
     rng = np.random.default_rng(0)
     nx, ns = 4, 6
 
@@ -44,12 +45,12 @@ def test_elastic_inequality_matrix_derivative(backend):
     G = jnp.array(G)
     penalty = jnp.array(20.0)
 
-    def loss(G_):
+    def loss(G_, h_):
         x = qpax.solve_qp_elastic_primal(
             Q,
             q,
             G_,
-            h,
+            h_,
             penalty,
             backend=backend,
             # note: tolerances assume x64
@@ -59,18 +60,27 @@ def test_elastic_inequality_matrix_derivative(backend):
         )
         return 0.5 * jnp.sum(x**2)
 
-    grad_ad = jax.grad(loss)(G)
+    grad_G_ad, grad_h_ad = jax.grad(loss, argnums=(0, 1))(G, h)
 
     eps = 1e-6
     directions = jnp.eye(G.size).reshape((-1, *G.shape))
-    grad_fd = jax.vmap(
+    grad_G_fd = jax.vmap(
         lambda direction: (
-            loss(G + eps * direction) - loss(G - eps * direction)
+            loss(G + eps * direction, h) - loss(G - eps * direction, h)
         )
         / (2 * eps)
     )(directions).reshape(G.shape)
 
-    np.testing.assert_allclose(grad_ad, grad_fd, rtol=1e-5, atol=1e-6)
+    directions = jnp.eye(h.size)
+    grad_h_fd = jax.vmap(
+        lambda direction: (
+            loss(G, h + eps * direction) - loss(G, h - eps * direction)
+        )
+        / (2 * eps)
+    )(directions)
+
+    np.testing.assert_allclose(grad_G_ad, grad_G_fd, rtol=1e-5, atol=1e-6)
+    np.testing.assert_allclose(grad_h_ad, grad_h_fd, rtol=1e-5, atol=1e-6)
 
 
 @pytest.mark.parametrize("backend", ["e", "i"])

--- a/test/test_elastic_qp.py
+++ b/test/test_elastic_qp.py
@@ -11,6 +11,8 @@ from qpax.implicit.elastic_qp import (
     solve_elastic_implicit_kkt_rhs,
 )
 
+jax.config.update("jax_enable_x64", True)
+
 
 @pytest.mark.parametrize("backend", ["e", "i"])
 def test_elastic_smoke(backend):
@@ -25,6 +27,50 @@ def test_elastic_smoke(backend):
     assert x.shape == (2,)
     assert jnp.all(jnp.isfinite(x))
     assert int(out[-2]) == 1
+
+@pytest.mark.parametrize("backend", ["e", "i"])
+def test_elastic_inequality_matrix_derivative(backend):
+    rng = np.random.default_rng(0)
+    nx, ns = 4, 6
+
+    factor = rng.standard_normal((nx, nx))
+    Q = jnp.array(factor @ factor.T + np.eye(nx))
+    q = jnp.array(rng.standard_normal(nx))
+    G = rng.standard_normal((ns, nx))
+    x0 = rng.standard_normal(nx)
+    h = jnp.array(
+        G @ x0 + np.array([0.0, 0.5, -0.1, 1.0, 0.3, -0.2])
+    )
+    G = jnp.array(G)
+    penalty = jnp.array(20.0)
+
+    def loss(G_):
+        x = qpax.solve_qp_elastic_primal(
+            Q,
+            q,
+            G_,
+            h,
+            penalty,
+            backend=backend,
+            # note: tolerances assume x64
+            solver_tol=1e-10,
+            target_kappa=1e-8,
+            max_iter=50,
+        )
+        return 0.5 * jnp.sum(x**2)
+
+    grad_ad = jax.grad(loss)(G)
+
+    eps = 1e-6
+    directions = jnp.eye(G.size).reshape((-1, *G.shape))
+    grad_fd = jax.vmap(
+        lambda direction: (
+            loss(G + eps * direction) - loss(G - eps * direction)
+        )
+        / (2 * eps)
+    )(directions).reshape(G.shape)
+
+    np.testing.assert_allclose(grad_ad, grad_fd, rtol=1e-5, atol=1e-6)
 
 
 @pytest.mark.parametrize("backend", ["e", "i"])

--- a/test/test_qp_derivatives.py
+++ b/test/test_qp_derivatives.py
@@ -10,6 +10,8 @@ from qpax import solve_qp_primal
 
 from .misc_test_utils import finite_difference, generate_random_qp
 
+jax.config.update("jax_enable_x64", True)
+
 
 def _make_my_f(backend):
     @functools.partial(jax.jit, static_argnames=())
@@ -59,3 +61,48 @@ def test_derivs(backend):
         print("error_norm: ", jnp.linalg.norm(derivs[i] - fd_deriv))
 
         assert jnp.linalg.norm(derivs[i] - fd_deriv) < (0.2 * jnp.linalg.norm(fd_deriv))
+
+@pytest.mark.parametrize("backend", ["e", "i"])
+def test_explicit_inequality_matrix_derivative(backend):
+    rng = np.random.default_rng(0)
+    nx, ns = 4, 6
+
+    factor = rng.standard_normal((nx, nx))
+    Q = jnp.array(factor @ factor.T + np.eye(nx))
+    q = jnp.array(rng.standard_normal(nx))
+    G = rng.standard_normal((ns, nx))
+    x0 = rng.standard_normal(nx)
+    h = jnp.array(
+        G @ x0 + np.array([0.0, 0.5, -0.1, 1.0, 0.3, -0.2])
+    )
+    G = jnp.array(G)
+    A = jnp.zeros((0, nx))
+    b = jnp.zeros(0)
+
+    def loss(G_):
+        x = solve_qp_primal(
+            Q,
+            q,
+            A,
+            b,
+            G_,
+            h,
+            backend=backend,
+            # note: tolerances assume x64
+            solver_tol=1e-10,
+            target_kappa=1e-8,
+        )
+        return 0.5 * jnp.sum(x**2)
+
+    grad_ad = jax.grad(loss)(G)
+
+    eps = 1e-6
+    directions = jnp.eye(G.size).reshape((-1, *G.shape))
+    grad_fd = jax.vmap(
+        lambda direction: (
+            loss(G + eps * direction) - loss(G - eps * direction)
+        )
+        / (2 * eps)
+    )(directions).reshape(G.shape)
+
+    np.testing.assert_allclose(grad_ad, grad_fd, rtol=1e-5, atol=1e-6)

--- a/test/test_qp_derivatives.py
+++ b/test/test_qp_derivatives.py
@@ -62,8 +62,9 @@ def test_derivs(backend):
 
         assert jnp.linalg.norm(derivs[i] - fd_deriv) < (0.2 * jnp.linalg.norm(fd_deriv))
 
+
 @pytest.mark.parametrize("backend", ["e", "i"])
-def test_explicit_inequality_matrix_derivative(backend):
+def test_inequality_parameter_derivatives(backend):
     rng = np.random.default_rng(0)
     nx, ns = 4, 6
 
@@ -79,14 +80,14 @@ def test_explicit_inequality_matrix_derivative(backend):
     A = jnp.zeros((0, nx))
     b = jnp.zeros(0)
 
-    def loss(G_):
+    def loss(G_, h_):
         x = solve_qp_primal(
             Q,
             q,
             A,
             b,
             G_,
-            h,
+            h_,
             backend=backend,
             # note: tolerances assume x64
             solver_tol=1e-10,
@@ -94,15 +95,24 @@ def test_explicit_inequality_matrix_derivative(backend):
         )
         return 0.5 * jnp.sum(x**2)
 
-    grad_ad = jax.grad(loss)(G)
+    grad_G_ad, grad_h_ad = jax.grad(loss, argnums=(0, 1))(G, h)
 
     eps = 1e-6
     directions = jnp.eye(G.size).reshape((-1, *G.shape))
-    grad_fd = jax.vmap(
+    grad_G_fd = jax.vmap(
         lambda direction: (
-            loss(G + eps * direction) - loss(G - eps * direction)
+            loss(G + eps * direction, h) - loss(G - eps * direction, h)
         )
         / (2 * eps)
     )(directions).reshape(G.shape)
 
-    np.testing.assert_allclose(grad_ad, grad_fd, rtol=1e-5, atol=1e-6)
+    directions = jnp.eye(h.size)
+    grad_h_fd = jax.vmap(
+        lambda direction: (
+            loss(G, h + eps * direction) - loss(G, h - eps * direction)
+        )
+        / (2 * eps)
+    )(directions)
+
+    np.testing.assert_allclose(grad_G_ad, grad_G_fd, rtol=1e-5, atol=1e-6)
+    np.testing.assert_allclose(grad_h_ad, grad_h_fd, rtol=1e-5, atol=1e-6)


### PR DESCRIPTION
Was doing some correctness tests with qpax as a reference implementation and saw some strange values coming out of the derivatives with respect to the inequality terms. Included is a test case to compare the dl_dG and dl_dh terms against finite differencing. It looks like with the explicit backend only (implicit was already correct), some terms were doubly-scaled by lam, leading to inaccurate values